### PR TITLE
[REF] pylint-conf: Remove o, i, k and v from good names variable

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -155,7 +155,7 @@ attr-rgx=[a-z_][a-z0-9_]{2,45}$
 argument-rgx=([a-z_][a-z0-9_]{2,45}$)
 variable-rgx=[a-z_][a-z0-9_]{1,45}$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-good-names=_,cr,uid,id,ids,_logger,o,e,i,k,v,checks,fast_suite
+good-names=_,cr,uid,id,ids,_logger,e,checks,fast_suite
 bad-names=
 
 [IMPORTS]


### PR DESCRIPTION
i: Commonly used in "for" loops of python.
o: Commonly used in report parser of odoo.
k, v: Commonly used to assign key and value of dictionaries python.

Silenced in the past because was good names in these time.
Now, we have use a most explicit name, please!