### PR TITLE
[REF] lint script: Remove dummy class invoke 'e.g. class1()'

### DIFF
--- a/fix_unused_imports/replace_import.py
+++ b/fix_unused_imports/replace_import.py
@@ -15,8 +15,8 @@ ALL_FIXES = [
     'remove_linenos_pylint_w0404', #  reimported
     'fix_relative_import',
     'fix_sort_import',
-    'snake_case2CamelCase',
     'rm_dummy_class_invoke',
+    'snake_case2CamelCase',
 ]
 
 """


### PR DESCRIPTION
You can test it with:
```python
python fix_unused_imports/replace_import.py MODULES_PATH rm_dummy_class_invoke
```