### PR TITLE
[REF] pylint_conf: Add the how to fix W0621 for fields using new api.

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -80,6 +80,22 @@ disable=E1002,E1101,E1120,E1121,E1123,W0201,W0212,W0221,W0223,W0232,W0511,W0613,
          # If this variable is internal of odoo/openerp and you can't change it then you should use a disable pylint message in this line.
          #   e.g. def method_function(self, cr, uid, ids, fields...)  # pylint: disable=W0621
          #   fields is a variable reserved of methods by odoo/openerp and is a class name reserved by odoo/openerp too.
+         #
+         # For new api you can fix it using fields_list instead fields. See the example in: https://github.com/odoo/odoo/blob/8.0/openerp/models.py#L1284-L1295
+         # e.g.
+         # @api.model
+         # def default_get(self, fields_list):
+         #     """ default_get(fields) -> default_values
+         #
+         #     Return default values for the fields in ``fields_list``. Default
+         #     values are determined by the context, user defaults, and the model
+         #     itself.
+         #
+         #     :param fields_list: a list of field names
+         #     :return: a dictionary mapping each field name to its corresponding
+         #         default value, if it has one.
+         #
+         #     """
 #W0622 - Redefining built-in 'id', can be fixed using a variable name
          # unreserved system like "ids".
          #


### PR DESCRIPTION
This PR is to add an example of:

- How to fix the pylint error `W0612 redefining name %r from outer scope (line %s)` in new api, when you are using the internal variable for Odoo `fields`. In this case is not necessary to mute that error, just use `fields_list` instead `fields`