### PR TITLE
[IMP] pylint.cfg: Adding the format check 'expected-line-ending-format'

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -298,6 +298,7 @@ defining-attr-methods=__init__,__new__,setUp
 max-line-length=80
 max-module-lines=10000
 indent-string='    '
+expected-line-ending-format=LF
 
 [SIMILARITIES]
 min-similarity-lines=14

--- a/conf/pylint_vauxoo_light_pr.cfg
+++ b/conf/pylint_vauxoo_light_pr.cfg
@@ -80,6 +80,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 
 [FORMAT]
 indent-string='    '
+expected-line-ending-format=LF
 
 [BASIC]
 class-rgx=[A-Z_][a-zA-Z0-9]{2,45}

--- a/conf/pylint_vauxoo_light_vim.cfg
+++ b/conf/pylint_vauxoo_light_vim.cfg
@@ -115,6 +115,7 @@ defining-attr-methods=__init__,__new__,setUp
 max-line-length=80
 max-module-lines=10000
 indent-string='    '
+expected-line-ending-format=LF
 
 [SIMILARITIES]
 min-similarity-lines=14


### PR DESCRIPTION
Related with https://github.com/PyCQA/pylint/issues/1616#issuecomment-322973093

In this PR all configuration related with pylint now has one new parameter called `expected-line-ending-format` this new parameter to the section `[FORMAT]` limit the character of the endline to `LF` that character is for the operation system `*Unix`

For example if the parameter `expected-line-ending-format` is set to `CRLF` if you operation system is `*Unix` then you see the follow warning in the `vim` 
```
[unexpected-line-ending-format] Unexpected line ending format. There is 'LF' while it should be 'CRLF'. [python/pylint]
```

