### PR TITLE
[FIX] conf: Disable check access-member-before-definition in vim configuration

### DIFF
--- a/conf/pylint_vauxoo_light_vim.cfg
+++ b/conf/pylint_vauxoo_light_vim.cfg
@@ -51,6 +51,7 @@ disable=no-member,
    po-lint,
    po-syntax-error,
    deprecated-openerp-xml-node,
+   access-member-before-definition,
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}


### PR DESCRIPTION
In odoo the inheritance is using the attribute `_inherit` and in the most code only use method defined in the API of odoo and for that the `check access-member-before-definition`  will be disabled

Fix https://github.com/Vauxoo/docker-odoo-image/issues/265