### PR TITLE
[ADD] conf: Adding file to emulate the runbot.odoo.com configuration of pylint

### DIFF
--- a/conf/pylint_odoo_core.cfg
+++ b/conf/pylint_odoo_core.cfg
@@ -1,0 +1,104 @@
+[MASTER]
+profile=no
+ignore=CVS,.git,scenarios,.bzr
+persistent=yes
+cache-size=500
+load-plugins=pylint.extensions.docstyle
+
+[MESSAGES CONTROL]
+disable=all
+enable=E0601,
+    W0123,
+    W0101,
+    print-statement,
+    backtick,
+    next-method-called,
+    misplaced-future,
+    relative-import,
+    deprecated-module,
+    import-star-module-level,
+    bad-builtin,
+    dict-iter-method,
+    dict-view-method,
+    long-suffix,
+    old-ne-operator
+    old-octal-operator,
+    parameter-unpacking,
+    invalid-string-codec,
+    metaclass-assignment,
+    deprecated-module,
+    exception-message-attribute,
+    indexing-exception,
+    old-raise-syntax,
+    raising-string,
+    unpacking-in-except,
+    no-comma-exception,
+
+[REPORTS]
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+files-output=no
+reports=no
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+[FORMAT]
+indent-string='    '
+expected-line-ending-format=LF
+
+[BASIC]
+class-rgx=[A-Z_][a-zA-Z0-9]{2,45}
+module-rgx=.*
+const-rgx=.*
+function-rgx=.*
+method-rgx=.*
+attr-rgx=.*
+argument-rgx=.*
+variable-rgx=.*
+inlinevar-rgx=.*
+
+[SIMILARITIES]
+ignore-comments=yes
+ignore-docstrings=yes
+
+[MISCELLANEOUS]
+notes=FIXME,TODO
+
+[IMPORTS]
+deprecated-modules=openerp.osv,
+    commands,
+    cPickle,
+    csv,
+    cStringIO,
+    md5,
+    urllib,
+    urllib2,
+    urlparse,
+    sgmllib,
+    sha,
+    cgi,
+    htmlentitydefs,
+    HTMLParser,
+    Queue,
+    StringIO,
+    UserDict,
+    UserString,
+    UserList
+bad-functions=apply,
+    cmp,
+    coerce,
+    execfile,
+    input,
+    intern,
+    long,
+    raw_input,
+    reload,
+    xrange,
+    long,
+    map,
+    filter,
+    zip,
+    basestring,
+    unichr,
+    unicode,
+    file,
+    reduce,


### PR DESCRIPTION
Create new file `conf/pylint_odoo_core.cfg` of configuration using as referent https://github.com/odoo/odoo/blob/saas-17/odoo/addons/test_pylint/tests/test_pylint.py