### PR TITLE
Revert "[REF] pylint.conf: Considering our partner like required authors"

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -10,7 +10,7 @@ extension-pkg-whitelist=lxml
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo,Odoo Community Association (OCA),Jarsa Sistemas"
+manifest_required_author="Vauxoo"
 manifest_required_keys=license,installable
 manifest_deprecated_keys=description,active
 

--- a/conf/pylint_vauxoo_light_pr.cfg
+++ b/conf/pylint_vauxoo_light_pr.cfg
@@ -7,7 +7,7 @@ load-plugins=pylint.extensions.docstyle, pylint.extensions.mccabe
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo,Odoo Community Association (OCA),Jarsa Sistemas"
+manifest_required_author="Vauxoo"
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 

--- a/conf/pylint_vauxoo_light_vim.cfg
+++ b/conf/pylint_vauxoo_light_vim.cfg
@@ -9,7 +9,7 @@ load-plugins=pylint_odoo, pylint.extensions.docstyle, pylint.extensions.mccabe
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo,Odoo Community Association (OCA),Jarsa Sistemas"
+manifest_required_author="Vauxoo"
 manifest_required_keys=license,installable
 manifest_deprecated_keys=description,active
 


### PR DESCRIPTION
This reverts commit e1457a0bf5560c74748023f827b625b0157a79ca.

It was causing errors because, by now, only one author may be specified
as required