### PR TITLE
[REF] pylint.conf: Consider our partner as possible required author

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -10,7 +10,9 @@ extension-pkg-whitelist=lxml
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo"
+manifest_required_authors=Vauxoo,
+   Odoo Community Association (OCA),
+   Jarsa Sistemas,
 manifest_required_keys=license,installable
 manifest_deprecated_keys=description,active
 

--- a/conf/pylint_vauxoo_light_pr.cfg
+++ b/conf/pylint_vauxoo_light_pr.cfg
@@ -7,7 +7,9 @@ load-plugins=pylint.extensions.docstyle, pylint.extensions.mccabe
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo"
+manifest_required_authors=Vauxoo,
+  Odoo Community Association (OCA),
+  Jarsa Sistemas,
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 

--- a/conf/pylint_vauxoo_light_vim.cfg
+++ b/conf/pylint_vauxoo_light_vim.cfg
@@ -9,7 +9,9 @@ load-plugins=pylint_odoo, pylint.extensions.docstyle, pylint.extensions.mccabe
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_author="Vauxoo"
+manifest_required_authors=Vauxoo,
+   Odoo Community Association (OCA),
+   Jarsa Sistemas,
 manifest_required_keys=license,installable
 manifest_deprecated_keys=description,active
 


### PR DESCRIPTION
The lint to detect required authors in modules's manifest
(manifest-required-author) now accepts multiple possible values, so this
commit includes our partner on those.

This is similar to e1457a0bf556, which had to be reverted, because it
was applied before the lint improvement

Closes https://github.com/Vauxoo/pylint-odoo/issues/157

Note:
This change was already applied on 86b1ca8fa22d and reverted on
c0809a2d2604, to solve the issue Vauxoo/pylint-odoo#159. However, this
is being re-aplied because it's unrelated to the aforementioned issue,
and it's addressed on PR Vauxoo/pylint-odoo#160