### PR TITLE
[FIX] pylint.cfg: method-rgx - Fixing wrong regex

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -290,8 +290,8 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|(_logger))$
 class-rgx=([a-z_][a-z0-9_]{2,45})|([A-Z_][a-zA-Z0-9]{2,45})$
 function-rgx=[a-z_][a-z0-9_]{2,45}$
 
-# Adding all unitest2 valida methods
-method-rgx=([a-z_][a-z0-9_]{2,45})|(addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest)$
+# Adding all unitest valid methods
+method-rgx=([a-z_][a-z0-9_]{2,45}|addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest)$
 
 attr-rgx=[a-z_][a-z0-9_]{2,45}$
 argument-rgx=([a-z_][a-z0-9_]{2,45}$)

--- a/conf/pylint_vauxoo_light_beta.cfg
+++ b/conf/pylint_vauxoo_light_beta.cfg
@@ -10,5 +10,7 @@ enabled2beta=po-lint,
     missing-return,
     fixme,
     javascript-lint,
+    invalid-name,
 # javascript-lint temp beta because we are using a new eslint (before jshint)
 # bad-docstring-quotes beta because have false negatives using decorator
+# invalid-name beta because the regex to detect them was buggy so it is enabling as beta in order to avoid red status for projects

--- a/conf/pylint_vauxoo_light_vim.cfg
+++ b/conf/pylint_vauxoo_light_vim.cfg
@@ -82,7 +82,7 @@ class-rgx=([a-z_][a-z0-9_]{2,45})|([A-Z_][a-zA-Z0-9]{2,45})$
 function-rgx=[a-z_][a-z0-9_]{2,45}$
 
 # Adding all unitest2 valid methods
-method-rgx=([a-z_][a-z0-9_]{2,45})|(addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest)$
+method-rgx=([a-z_][a-z0-9_]{2,45}|addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest)$
 
 attr-rgx=[a-z_][a-z0-9_]{2,45}$
 argument-rgx=([a-z_][a-z0-9_]{2,45}$)


### PR DESCRIPTION
For invalid-name check the regex was wrong
Now it is fixed removing () delimiters