### PR TITLE
[REF] pylint.cfg: Increase to 59 named of methods and classes

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -287,15 +287,15 @@ no-docstring-rgx=__.*__
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|(_logger))$
 #class-rgx=[A-Z_][a-zA-Z0-9]+$
-class-rgx=([a-z_][a-z0-9_]{2,45})|([A-Z_][a-zA-Z0-9]{2,45})$
-function-rgx=[a-z_][a-z0-9_]{2,45}$
+class-rgx=([a-z_][a-z0-9_]{2,59})|([A-Z_][a-zA-Z0-9]{2,59})$
+function-rgx=[a-z_][a-z0-9_]{2,59}$
 
 # Adding all unitest valid methods
-method-rgx=([a-z_][a-z0-9_]{2,45}|addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest)$
+method-rgx=([a-z_][a-z0-9_]{2,59}|addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest|test\_.*)$
 
-attr-rgx=[a-z_][a-z0-9_]{2,45}$
-argument-rgx=([a-z_][a-z0-9_]{2,45}$)
-variable-rgx=[a-z_][a-z0-9_]{1,45}$
+attr-rgx=[a-z_][a-z0-9_]{2,59}$
+argument-rgx=([a-z_][a-z0-9_]{2,59}$)
+variable-rgx=[a-z_][a-z0-9_]{1,59}$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 good-names=_,cr,uid,id,ids,_logger,o,e,i,k,v,checks,fast_suite,maxDiff
 bad-names=

--- a/conf/pylint_vauxoo_light_pr.cfg
+++ b/conf/pylint_vauxoo_light_pr.cfg
@@ -85,7 +85,7 @@ indent-string='    '
 expected-line-ending-format=LF
 
 [BASIC]
-class-rgx=[A-Z_][a-zA-Z0-9]{2,45}
+class-rgx=[A-Z_][a-zA-Z0-9]{2,59}
 module-rgx=.*
 const-rgx=.*
 function-rgx=.*

--- a/conf/pylint_vauxoo_light_vim.cfg
+++ b/conf/pylint_vauxoo_light_vim.cfg
@@ -78,15 +78,15 @@ no-docstring-rgx=__.*__
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|(_logger))$
 #class-rgx=[A-Z_][a-zA-Z0-9]+$
-class-rgx=([a-z_][a-z0-9_]{2,45})|([A-Z_][a-zA-Z0-9]{2,45})$
-function-rgx=[a-z_][a-z0-9_]{2,45}$
+class-rgx=([a-z_][a-z0-9_]{2,59})|([A-Z_][a-zA-Z0-9]{2,59})$
+function-rgx=[a-z_][a-z0-9_]{2,59}$
 
 # Adding all unitest2 valid methods
-method-rgx=([a-z_][a-z0-9_]{2,45}|addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest)$
+method-rgx=([a-z_][a-z0-9_]{2,59}|addTypeEqualityFunc|addCleanup|setUp|setUpClass|tearDownClass|tearDown|countTestCases|defaultTestResult|shortDescription|skipTest|runTest)$
 
-attr-rgx=[a-z_][a-z0-9_]{2,45}$
-argument-rgx=([a-z_][a-z0-9_]{2,45}$)
-variable-rgx=[a-z_][a-z0-9_]{1,45}$
+attr-rgx=[a-z_][a-z0-9_]{2,59}$
+argument-rgx=([a-z_][a-z0-9_]{2,59}$)
+variable-rgx=[a-z_][a-z0-9_]{1,59}$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 good-names=_,cr,uid,id,ids,_logger,o,e,i,k,v,checks,fast_suite
 bad-names=


### PR DESCRIPTION
And allow infinite length for test_ methods.
Since that we have increased the global line-length value
And test_ methods are not invoked so it could be used a big name to be explicit