### PR TITLE
[ADD] license_allowed: add 'OPL-1' in license allowed

### DIFF
--- a/conf/pylint_vauxoo_light_pr.cfg
+++ b/conf/pylint_vauxoo_light_pr.cfg
@@ -7,6 +7,10 @@ load-plugins=pylint.extensions.docstyle, pylint.extensions.mccabe
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,
+    GPL-3,GPL-3 or any later version,LGPL-3,
+    Other OSI approved licence,Other proprietary,
+    OEEL-1, OPL-1,
 manifest_required_authors=Vauxoo,
   Odoo Community Association (OCA),
   Jarsa Sistemas,

--- a/conf/pylint_vauxoo_light_vim.cfg
+++ b/conf/pylint_vauxoo_light_vim.cfg
@@ -9,6 +9,10 @@ load-plugins=pylint_odoo, pylint.extensions.docstyle, pylint.extensions.mccabe
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,
+    GPL-3,GPL-3 or any later version,LGPL-3,
+    Other OSI approved licence,Other proprietary,
+    OEEL-1, OPL-1,
 manifest_required_authors=Vauxoo,
    Odoo Community Association (OCA),
    Jarsa Sistemas,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When trying to publish the apps in the odoo store, it sends us the following error:

Module not installable: Please change the license of your module from OEEL-1 to OPL-1
https://git.vauxoo.com/vauxoo/apps/uploads/6a0376c1d56b6a06fbb081c78f0f2149/image.png

But when using this license in the modules: the lints send the following error:
License "OPL-1" not allowed in manifest file.

Current behavior before PR:
pylint-odoo check license-allowed lint when use "OPL-1".

Desired behavior after PR is merged:
pylint-odoo does not check license-allowed for "OPL-1".

Fix #66 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr