### PR TITLE
[REF] pylint-conf: Disable new useless checks of pylint v2.11.1

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -69,6 +69,15 @@ disable=no-member,
    self-cls-assignment,
    try-except-raise,
    raise-missing-from,
+   arguments-renamed,
+   bad-option-value,
+   c-extension-no-member,
+   consider-using-dict-items,
+   consider-using-f-string,
+   cyclic-import,
+   import-self,
+   unspecified-encoding,
+   unused-private-member,
 
 # odoolint disabled because this checks is available just in changed modules in PR conf.
 # import-error Because odoo use incompatible sys-modules https://bitbucket.org/logilab/pylint/issues/616/modules-renamed-with-sysmodules-are-unable
@@ -92,6 +101,15 @@ disable=no-member,
 # self-cls-assignment: Odoo uses this valid sentence self = self.with_context(...)
 # try-except-raise: Valid case when you want to raise a exception but not another one.
 # raise-missing-from: We are not using this style right now
+# consider-using-f-string: We don't like force to use f-string (yet)
+# unspecified-encoding: utf-8 is the default and the used for us
+# c-extension-no-member: We are not installing all the packages so can't be inspected
+# import-self: It is raising error for "from . import models" and it is used a lot
+# bad-option-value: Raises error when a check doesn't exists but what about multi-compatibility
+# arguments-renamed: It is raising weird errors
+# consider-using-dict-items: It is only a style but not big deal
+# cyclic-import: Raises error when 2 files use "from . import models" and it is used a lot
+# unused-private-member: We can define _methods unused in the same class but inheriting
 
 #***Enabled and how to fix***
 #E1103 - maybe-no-member

--- a/conf/pylint_vauxoo_light_beta.cfg
+++ b/conf/pylint_vauxoo_light_beta.cfg
@@ -13,6 +13,16 @@ enabled2beta=po-lint,
     super-with-arguments,
     translation-positional-used,
     test-folder-imported,
+    # New pylint version
+    # TODO: Remove after a while
+    use-a-generator,
+    consider-using-with,
+    simplifiable-condition,
+    use-dict-literal,
+    use-maxsplit-arg,
+    consider-using-min-builtin,
+    consider-using-in,
+    format-string-without-interpolation
 # javascript-lint temp beta because we are using a new eslint (before jshint)
 # bad-docstring-quotes beta because have false negatives using decorator
 # super-with-arguments beta temporally because we have a lot and we need to run a auto-fix process


### PR DESCRIPTION
pylint v2.11.1 added new checks a few of them are useless for Odoo world

This PR silent them

Other ones were added to beta in order to avoid red pipelines