### PR TITLE
[REF] pylint.cfg: Disable keyword-arg-before-vararg

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -78,6 +78,7 @@ disable=no-member,
    import-self,
    unspecified-encoding,
    unused-private-member,
+   keyword-arg-before-vararg,
 
 # odoolint disabled because this checks is available just in changed modules in PR conf.
 # import-error Because odoo use incompatible sys-modules https://bitbucket.org/logilab/pylint/issues/616/modules-renamed-with-sysmodules-are-unable
@@ -110,6 +111,7 @@ disable=no-member,
 # consider-using-dict-items: It is only a style but not big deal
 # cyclic-import: Raises error when 2 files use "from . import models" and it is used a lot
 # unused-private-member: We can define _methods unused in the same class but inheriting
+# keyword-arg-before-vararg: Disabled because it raises error for `def method(self, kw1, *args, **kwargs)` but we like using kw1 as the first one even if it is not set as `kw1=something`
 
 #***Enabled and how to fix***
 #E1103 - maybe-no-member


### PR DESCRIPTION
 it raises error for `def method(self, kw1, *args, **kwargs)` but we like using kw1 as the first one even if it is not set as `kw1=something`