### PR TITLE
[REF] pylint.cfg: Disable ungrouped-imports

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -79,6 +79,7 @@ disable=no-member,
    unspecified-encoding,
    unused-private-member,
    keyword-arg-before-vararg,
+   ungrouped-imports,
 
 # odoolint disabled because this checks is available just in changed modules in PR conf.
 # import-error Because odoo use incompatible sys-modules https://bitbucket.org/logilab/pylint/issues/616/modules-renamed-with-sysmodules-are-unable
@@ -112,6 +113,7 @@ disable=no-member,
 # cyclic-import: Raises error when 2 files use "from . import models" and it is used a lot
 # unused-private-member: We can define _methods unused in the same class but inheriting
 # keyword-arg-before-vararg: Disabled because it raises error for `def method(self, kw1, *args, **kwargs)` but we like using kw1 as the first one even if it is not set as `kw1=something`
+# ungrouped-imports: We uses a lot "from odoo import fields;from odoo.tools import ..." so it is a valid case for us
 
 #***Enabled and how to fix***
 #E1103 - maybe-no-member


### PR DESCRIPTION
We uses a lot "from odoo import fields;from odoo.tools import ..." so it is a valid case for us