### PR TITLE
[REF] pylint.cfg: Using class-const-naming-style as snake_case

### DIFF
--- a/conf/pylint_vauxoo_light.cfg
+++ b/conf/pylint_vauxoo_light.cfg
@@ -320,6 +320,7 @@ method-rgx=([a-z_][a-z0-9_]{2,59}|addTypeEqualityFunc|addCleanup|setUp|setUpClas
 attr-rgx=[a-z_][a-z0-9_]{2,59}$
 argument-rgx=([a-z_][a-z0-9_]{2,59}$)
 variable-rgx=[a-z_][a-z0-9_]{1,59}$
+class-const-naming-style=SNAKE_CASE
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 good-names=_,cr,uid,id,ids,_logger,o,e,i,k,v,checks,fast_suite,maxDiff
 bad-names=


### PR DESCRIPTION
For the following python code:

    class ModificationRequestTypes(Enum):
        class_constant = 4

pylint is raising the following error:

  - Class constant name "class_constant" doesn't conform to UPPER_CASE naming style

But for Odoo style we are using snake case since that it could be a name of column in the database